### PR TITLE
Fix update code

### DIFF
--- a/src/components/CodeEditor/CodeEditor.jsx
+++ b/src/components/CodeEditor/CodeEditor.jsx
@@ -30,6 +30,12 @@ export default function CodeEditor(props) {
     checked ? setTheme("vs-dark") : setTheme("vs-light");
   }, [checked]);
 
+  useEffect(() => {
+    if (editorRef.current) {
+      editorRef.current.setValue(props.defaultCode);
+    }
+  }, [props.defaultCode]);
+
   async function compile() {
     const response = await fetch("http://localhost:3001/compile", {
       headers: {

--- a/src/components/SectionInteraction/SectionInteraction.jsx
+++ b/src/components/SectionInteraction/SectionInteraction.jsx
@@ -1,5 +1,5 @@
 // react
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 // Material UI Components
 import { Box } from "@mui/material";
@@ -22,6 +22,12 @@ const SectionInteractionContainer = styled(Box)(() => ({
 
 function SectionInteractionContent(props) {
   const [output, setOutput] = useState({});
+
+  useEffect(() => {
+    // clear output
+    setOutput({});
+    // TODO: if contract was previously deployed, get the previous output ( might have to store things to a db for this)
+  }, [props.defaultCode]);
 
   if (props.hasCodeEditor) {
     return (

--- a/src/data/content/SolidityAdvanced.js
+++ b/src/data/content/SolidityAdvanced.js
@@ -1,0 +1,3 @@
+const content = `## Solidity Advanced`;
+
+export default content;

--- a/src/data/content/SolidityBasic.js
+++ b/src/data/content/SolidityBasic.js
@@ -1,0 +1,3 @@
+const content = `## Solidity Basic`;
+
+export default content;

--- a/src/data/course.js
+++ b/src/data/course.js
@@ -72,6 +72,7 @@ const course = {
         {
           title: "Hello World",
           url: "hello-world",
+          contentUrl: "SolidityBasic.js",
           hasCodeEditor: true,
           defaultCode:
             'pragma solidity ^0.8.10;\n\ncontract HelloWorld {\n\tstring public greet = "Hello World!";\n}\n\n\n',


### PR DESCRIPTION
Watching for props.defaultCode to change. When that happens, set the code editors value and clear the output. 

In the future, we should offer the ability to save a draft ( or auto save ) so that when they come back to that lesson, their work is restored. Shouldn't be hard if users are connected to a wallet, we can use their address as their "unique ID" to store things in a DB or even easier in local storage. 

Also, if a contract was previously deployed, it would be nice if the output panel could be restored with the last deployment info. Also future work though. 