### PR TITLE
add secondary content / hide second panel if empty

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -49,6 +49,7 @@ function App() {
                       element={
                         <SectionPage
                           contentUrl={section.contentUrl}
+                          secondaryContentUrl={section.secondaryContentUrl}
                           hasCodeEditor={section.hasCodeEditor}
                           defaultCode={section.defaultCode}
                         />

--- a/src/components/SectionContent/SectionContent.js
+++ b/src/components/SectionContent/SectionContent.js
@@ -29,6 +29,11 @@ const ContentContainer = styled(Box)(() => ({
   fontFamily: "Lato",
 }));
 
+const Content = styled(Box)(() => ({
+  maxWidth: "750px",
+  margin: "auto",
+}));
+
 export default function SectionContent(props) {
   const [content, setContent] = useState("");
   const theme = useTheme();
@@ -57,11 +62,13 @@ export default function SectionContent(props) {
         border: theme.palette.border,
       }}
     >
-      <ReactMarkdown
-        rehypePlugins={[rehypeRaw, rehypePrism]}
-        id="markdown"
-        children={content}
-      />
+      <Content>
+        <ReactMarkdown
+          rehypePlugins={[rehypeRaw, rehypePrism]}
+          id="markdown"
+          children={content}
+        />
+      </Content>
     </ContentContainer>
   );
 }

--- a/src/components/SectionPage/SectionPage.js
+++ b/src/components/SectionPage/SectionPage.js
@@ -36,14 +36,22 @@ export default function SectionPage(props) {
         }}
         contentUrl={props.contentUrl}
       ></SectionContent>
-      <SectionInteraction
-        id="section-interaction"
-        sx={{
-          backgroundColor: theme.palette.backgroundColor,
-        }}
-        hasCodeEditor={props.hasCodeEditor}
-        defaultCode={props.defaultCode}
-      ></SectionInteraction>
+      {props.hasCodeEditor && (
+        <SectionInteraction
+          id="section-interaction"
+          sx={{
+            backgroundColor: theme.palette.backgroundColor,
+          }}
+          hasCodeEditor={props.hasCodeEditor}
+          defaultCode={props.defaultCode}
+        ></SectionInteraction>
+      )}
+      {props.secondaryContentUrl && (
+        <SectionContent
+          id="section-secondary-content"
+          contentUrl={props.secondaryContentUrl}
+        ></SectionContent>
+      )}
     </SectionPageContainer>
   );
 }

--- a/src/data/course.js
+++ b/src/data/course.js
@@ -8,8 +8,6 @@ const course = {
           title: "Course Overview",
           url: "course-overview",
           contentUrl: "CourseOverview.js",
-          hasCodeEditor: false,
-          defaultCode: "",
         },
         {
           title: "Wallet setup",


### PR DESCRIPTION
Now you can add secondary content ( content on the right hand side ) using the "secondaryContentUrl" prop in the course object .

If neither hasCodeEditor or secdonaryContentUrl is set, the contentUrl takes up the whole area.  